### PR TITLE
fix: fix empty CallbackResult in PutObjectResult

### DIFF
--- a/src/AlibabaCloud.OSS.V2/Models/Model.ObjectBasic.cs
+++ b/src/AlibabaCloud.OSS.V2/Models/Model.ObjectBasic.cs
@@ -287,6 +287,11 @@ namespace AlibabaCloud.OSS.V2.Models
         /// It is valid only when the callback is set.
         /// </summary>
         public string? CallbackResult => InnerBody as string;
+
+        public PutObjectResult()
+        {
+            BodyFormat = "string";
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
### Problem
The `CallbackResult` property in `PutObjectResult` always returns null even when the business server returns a callback body. This is because the `BodyFormat` is not initialized, causing the deserializer to skip the body content.
<img width="837" height="646" alt="image" src="https://github.com/user-attachments/assets/c0fc3bc6-adb4-47e5-91f5-56a0f7a1c1f0" />
<img width="620" height="307" alt="image" src="https://github.com/user-attachments/assets/3f8d8937-805a-4c3d-9716-329c9ab9e3fa" />

### Solution
Initialize `BodyFormat` to `"string"` in the `PutObjectResult` constructor to ensure the `InnerBody` is correctly populated by `DeserializerAnyBody`.

### Changes
- Modified `AlibabaCloud.SDK.OSS.V2.Models.PutObjectResult` to set `BodyFormat = "string"` in the constructor.

### Verification
- [x] Verified that `CallbackResult` now correctly contains the JSON response from the callback server.
<img width="697" height="307" alt="image" src="https://github.com/user-attachments/assets/02feb853-30a8-49ed-b0d3-10ae8503e521" />
