### PR TITLE
fix: fix incorrect deserialization of CompleteMultipartUpload when Callback is set

### DIFF
--- a/src/AlibabaCloud.OSS.V2/Client.ObjectMultipart.cs
+++ b/src/AlibabaCloud.OSS.V2/Client.ObjectMultipart.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using AlibabaCloud.OSS.V2.Transform;
+using static AlibabaCloud.OSS.V2.Transform.Serde;
 
 namespace AlibabaCloud.OSS.V2
 {
@@ -121,7 +122,12 @@ namespace AlibabaCloud.OSS.V2
 
             Models.ResultModel result = new Models.CompleteMultipartUploadResult();
 
-            Serde.DeserializeOutput(ref result, ref output, Serde.DeserializeCompleteMultipartUpload);
+            CustomDeserializer outputDeserializer =
+                string.IsNullOrEmpty(request.Callback)
+                ? Serde.DeserializeCompleteMultipartUpload
+                : Serde.DeserializeCompleteMultipartUploadCallback;
+
+            Serde.DeserializeOutput(ref result, ref output, outputDeserializer);
 
             return (Models.CompleteMultipartUploadResult)result;
         }

--- a/src/AlibabaCloud.OSS.V2/Models/Model.ObjectBasic.cs
+++ b/src/AlibabaCloud.OSS.V2/Models/Model.ObjectBasic.cs
@@ -287,6 +287,11 @@ namespace AlibabaCloud.OSS.V2.Models
         /// It is valid only when the callback is set.
         /// </summary>
         public string? CallbackResult => InnerBody as string;
+
+        public PutObjectResult()
+        {
+            BodyFormat = "string";
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
### Problem
When calling CompleteMultipartUploadAsync with the Callback parameter set, OSS returns the response body from the business server (typically JSON) instead of the standard XML. The current implementation unconditionally uses Serde.DeserializeCompleteMultipartUpload to parse the response, leading to deserialization failures.

<img width="1032" height="514" alt="image" src="https://github.com/user-attachments/assets/bdce2a80-429e-43e0-be9f-80072f3bc021" />

<img width="1229" height="332" alt="image" src="https://github.com/user-attachments/assets/053e324d-d043-4fd2-8830-2cd655cd328c" />

### Solution
This PR introduces a conditional check: if Callback is present in the request, it uses DeserializeCompleteMultipartUploadCallback to correctly capture the business server's response into the CallbackResult property.

### Changes
- Modified CompleteMultipartUploadAsync to dynamically select the deserializer based on the request.Callback property.

### Verification
- [x] The CallbackResult property now correctly contains the JSON string returned by the callback server, and no XmlException is thrown.
<img width="780" height="415" alt="image" src="https://github.com/user-attachments/assets/5ac71941-d9bd-4db7-810d-17de44c6cf40" />
